### PR TITLE
improv: units

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -1741,7 +1741,7 @@ Display mounted volumes directly via `vol`.
 				<true/>
 			</dict>
 			<key>description</key>
-			<string>CPU threshold, percentage below which CPU is not displayed</string>
+			<string>minimum CPU threshold in % for displaying usage</string>
 			<key>label</key>
 			<string></string>
 			<key>type</key>
@@ -1762,7 +1762,7 @@ Display mounted volumes directly via `vol`.
 				<true/>
 			</dict>
 			<key>description</key>
-			<string>memory threshold, Mb below which memory usage is not displayed</string>
+			<string>minimum memory threshold in MB for displaying usage</string>
 			<key>label</key>
 			<string></string>
 			<key>type</key>

--- a/scripts/list-processes.js
+++ b/scripts/list-processes.js
@@ -72,7 +72,7 @@ function run() {
 
 			// Memory, CPU & root
 			let memory = (Number.parseInt(memoryStr) / 1024).toFixed(0).toString(); // real memory
-			memory = Number.parseInt(memory) > memoryThresholdMb ? memory + "Mb" : "";
+			memory = Number.parseInt(memory) > memoryThresholdMb ? memory + " MB" : "";
 			const cpu = Number.parseFloat(cpuStr) > cpuThresholdPercent ? cpuStr + "%" : "";
 			const isRootUser = isRoot === "root" ? " ⭕" : "";
 


### PR DESCRIPTION
## What problem does this PR solve?

Inappropriate wording (unit) in script filter result and description. `Mb` is for megabits. 

## How does the PR solve it?

Used `MB` for megabytes. 

### Before

<img width="764" alt="Screenshot 2025-06-11 at 11 07 50 PM" src="https://github.com/user-attachments/assets/c9fd6ec2-bef4-4bff-bb09-0bb8d6a1b00c" />

### After

<img width="764" alt="Screenshot 2025-06-11 at 11 01 55 PM" src="https://github.com/user-attachments/assets/4c7dd265-4e6a-4f11-9c64-68debccb0464" />

## Checklist
- [x] Used only `camelCase` variable names.
- [x] If functionality is added or modified, also made respective changes to the
  `README.md` and the internal workflow documentation.
