### PR TITLE
fix: bluetooth connection logic

### DIFF
--- a/scripts/bluetooth-connect.js
+++ b/scripts/bluetooth-connect.js
@@ -15,8 +15,13 @@ function run(argv) {
 	const device = devices.find((d) => d.addressString.js === selectedDeviceAddress);
 	if (!device) return "⚠️ Unknown error.";
 
-	// SIC function call without `()`, due to being Objective-C?
-	device.isConnected ? device.closeConnection : device.openConnection;
+	if (device.isConnected) {
+		// SIC function call without `()`, due to being Objective-C?
+		device.closeConnection
+	} else {
+		// SIC function call works when null is passed as argument, I don't understand why
+		device.openConnection(null)
+	}
 
 	// notification
 	const action = device.isConnected ? "🔴 Disconnected from" : "🟢 Connected to";


### PR DESCRIPTION
Script wouldn't work to open a connection with a bluetooth device. Passing in an argument as "null" did the trick, but I must admit I don't understand why.

## Problem statement
"blue" command wasn't working to establish a connection to a bluetooth device

## Proposed solution
`openConnection(null)` works with null as its first argument

## AI usage disclosure
I pasted the code to an AI agent, and it mentioned that occasionally JXA can be finicky with objectiveC code interface, and passing "null" as an argument sometimes work. It did the trick here.

## Checklist
- [x] Variable names follow `camelCase` convention.
- [x] All AI-generated code has been reviewed by a human.
- [x] Documentation (`README.md` and internal workflow docs) has been updated
  for any new or modified functionality.
